### PR TITLE
Misc fixes 3

### DIFF
--- a/contracts/PurchaseExecutor.vy
+++ b/contracts/PurchaseExecutor.vy
@@ -136,7 +136,7 @@ def offer_expired() -> bool:
 @internal
 def _start_unless_started():
     if self.offer_started_at == 0:
-        assert ERC20(LDO_TOKEN).balanceOf(self) == self.ldo_allocations_total, "not funded"
+        assert ERC20(LDO_TOKEN).balanceOf(self) >= self.ldo_allocations_total, "not funded"
         started_at: uint256 = block.timestamp
         expires_at: uint256 = started_at + self.offer_expiration_delay
         self.offer_started_at = started_at

--- a/tests/test_ldo_purchase.py
+++ b/tests/test_ldo_purchase.py
@@ -321,10 +321,10 @@ def test_recover_erc20_can_return_dai_tokens_to_dao_vault_after_exparation(ldo_h
     assert dai_token.balanceOf(executor) == 0
     assert dai_token.balanceOf(dao_agent) == executor_dai_balance + dao_agent_dai_balance
 
-    purchase_evt = helpers.assert_single_event_named('ERC20Recovered', tx)
-    assert purchase_evt['requested_by'] == stranger
-    assert purchase_evt['token'] == dai_token.address
-    assert purchase_evt['amount'] == 10**18
+    recover_evt = helpers.assert_single_event_named('ERC20Recovered', tx)
+    assert recover_evt['requested_by'] == stranger
+    assert recover_evt['token'] == dai_token.address
+    assert recover_evt['amount'] == 10**18
 
 
 def test_recover_erc20_can_return_all_ldo_tokens_to_dao_vault_after_exparation(executor, dao_agent, ldo_token, stranger, helpers):
@@ -344,10 +344,10 @@ def test_recover_erc20_can_return_all_ldo_tokens_to_dao_vault_after_exparation(e
     assert ldo_token.balanceOf(executor) == 0
     assert ldo_token.balanceOf(dao_agent) == dao_agent_ldo_balance + executor_ldo_balance
 
-    purchase_evt = helpers.assert_single_event_named('ERC20Recovered', tx)
-    assert purchase_evt['requested_by'] == stranger
-    assert purchase_evt['token'] == ldo_token.address
-    assert purchase_evt['amount'] == executor_ldo_balance
+    recover_evt = helpers.assert_single_event_named('ERC20Recovered', tx)
+    assert recover_evt['requested_by'] == stranger
+    assert recover_evt['token'] == ldo_token.address
+    assert recover_evt['amount'] == executor_ldo_balance
 
 
 def test_recover_erc20_can_return_unsold_ldo_tokens_to_dao_vault_after_exparation(helpers, accounts, executor, dao_agent, ldo_token, dai_token, stranger):
@@ -376,10 +376,10 @@ def test_recover_erc20_can_return_unsold_ldo_tokens_to_dao_vault_after_exparatio
     assert ldo_token.balanceOf(executor) == 0
     assert ldo_token.balanceOf(dao_agent) == dao_agent_ldo_balance + executor_ldo_balance
 
-    purchase_evt = helpers.assert_single_event_named('ERC20Recovered', tx)
-    assert purchase_evt['requested_by'] == stranger
-    assert purchase_evt['token'] == ldo_token.address
-    assert purchase_evt['amount'] == executor_ldo_balance
+    recover_evt = helpers.assert_single_event_named('ERC20Recovered', tx)
+    assert recover_evt['requested_by'] == stranger
+    assert recover_evt['token'] == ldo_token.address
+    assert recover_evt['amount'] == executor_ldo_balance
 
 
 def test_can_recover_excess_funding_to_treasury(helpers, accounts, non_started_executor, dao_agent, ldo_holder, ldo_token, dai_token, stranger):

--- a/tests/test_offer_start.py
+++ b/tests/test_offer_start.py
@@ -89,6 +89,25 @@ def test_offer_can_be_started_by_anyone_after_funding(
     assert start_evt['expires_at'] == tx.timestamp + OFFER_EXPIRATION_DELAY
 
 
+def test_offer_can_be_started_with_excess_funding(
+    stranger,
+    ldo_holder,
+    ldo_token,
+    deployed_executor,
+    funding_vote_id,
+    helpers
+):
+    helpers.pass_and_exec_dao_vote(funding_vote_id)
+
+    # transfer more LDO to the executor
+    ldo_token.transfer(deployed_executor, 10**18, { 'from': ldo_holder })
+
+    deployed_executor.start({ 'from': stranger })
+
+    assert deployed_executor.offer_started()
+    assert not deployed_executor.offer_expired()
+
+
 def test_offer_automatically_starts_after_funding_on_first_deposit(
     accounts,
     deployed_executor,


### PR DESCRIPTION
* Fix a potential attack vector allowing one to botch the sale and irreversibly lock LDO tokens that were intended to be sold by sending 1 wei LDO to the funded but not yet started executor contract.
* Add more tests.